### PR TITLE
Disallow x-varnish-token validation

### DIFF
--- a/varnish/conf/default.vcl
+++ b/varnish/conf/default.vcl
@@ -20,9 +20,9 @@ sub vcl_recv {
   unset req.http.forwarded;
   # To allow API Platform to ban by cache tags
   if (req.method == "BAN") {
-    if (req.http.x-varnish-token != std.getenv("VARNISH_PURGE_TOKEN")) {
-      return (synth(405, "Not allowed"));
-    }
+#    if (req.http.x-varnish-token != std.getenv("VARNISH_PURGE_TOKEN")) {
+#      return (synth(405, "Not allowed"));
+#    }
     if (req.http.ApiPlatform-Ban-Regex) {
       ban("obj.http.Cache-Tags ~ " + req.http.ApiPlatform-Ban-Regex);
       return (synth(200, "Ban added"));


### PR DESCRIPTION
Temporaly disallowed in order to allow PATCH requests without any token